### PR TITLE
layout 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
+        "@mui/icons-material": "^5.6.2",
         "@mui/material": "^5.6.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -677,6 +678,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.6.2.tgz",
+      "integrity": "sha512-9QdI7axKuBAyaGz4mtdi7Uy1j73/thqFmEuxpJHxNC7O8ADEK1Da3t2veK2tgmsXsUlAHcAG63gg+GvWWeQNqQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@mui/material": {
       "version": "5.6.1",
@@ -5613,6 +5639,14 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         }
+      }
+    },
+    "@mui/icons-material": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.6.2.tgz",
+      "integrity": "sha512-9QdI7axKuBAyaGz4mtdi7Uy1j73/thqFmEuxpJHxNC7O8ADEK1Da3t2veK2tgmsXsUlAHcAG63gg+GvWWeQNqQ==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "@mui/material": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
+    "@mui/icons-material": "^5.6.2",
     "@mui/material": "^5.6.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
 import { Suspense } from 'react';
+import LayoutContainer from './components/layout';
 import Routes from './routes';
 
 function App() {
   return (
     <Suspense fallback={null}>
-      <Routes />
+      <LayoutContainer>
+        <Routes />
+      </LayoutContainer>
     </Suspense>
   );
 }

--- a/src/components/custom/alert.tsx
+++ b/src/components/custom/alert.tsx
@@ -1,0 +1,42 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  content?: string;
+}
+
+/** custom modal(alert) - 확인, 취소버튼이 있는 모달 */
+const CustomAlert = ({ onClose, open, title = 'title', content = 'content' }: Props) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby='alert-dialog-title'
+      aria-describedby='alert-dialog-description'
+    >
+      <DialogTitle id='alert-dialog-title'>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id='alert-dialog-description'>{content}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} style={{ color: 'black' }}>
+          닫기
+        </Button>
+        <Button onClick={onClose} autoFocus>
+          확인
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CustomAlert;

--- a/src/components/custom/index.ts
+++ b/src/components/custom/index.ts
@@ -1,0 +1,1 @@
+export { default as CustomAlert } from './alert';

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,5 +1,7 @@
+import { memo } from 'react';
+
 const LayoutHeader = () => {
   return <header className='absolute h-header w-full bg-gray-200'></header>;
 };
 
-export default LayoutHeader;
+export default memo(LayoutHeader);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,0 +1,5 @@
+const LayoutHeader = () => {
+  return <header className='absolute h-header w-full bg-gray-200'></header>;
+};
+
+export default LayoutHeader;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,7 +1,27 @@
-import { memo } from 'react';
+import { lazy, memo } from 'react';
+import LogoutIcon from '@mui/icons-material/Logout';
+import { useState } from 'react';
+
+const CustomAlert = lazy(() => import('src/components/custom/alert'));
 
 const LayoutHeader = () => {
-  return <header className='absolute h-header w-full bg-gray-200'></header>;
+  const [open, setOpen] = useState(false);
+
+  const onClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <header className='fixed h-header w-full bg-gray-200'>
+      <div
+        className='absolute right-0 m-4 cursor-pointer rounded-full bg-white p-3'
+        onClick={() => setOpen(true)}
+      >
+        <LogoutIcon />
+      </div>
+      <CustomAlert {...{ onClose, open }} title='로그아웃' content='정말 로그아웃 하시겠습니까?' />
+    </header>
+  );
 };
 
 export default memo(LayoutHeader);

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { ReactNode } from 'react';
 import LayoutHeader from './header';
 import LayoutNavigation from './navigation';
@@ -16,4 +17,4 @@ const LayoutContainer = ({ children }: Props) => {
   );
 };
 
-export default LayoutContainer;
+export default memo(LayoutContainer);

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import LayoutHeader from './header';
+import LayoutNavigation from './navigation';
+
+type Props = {
+  children: ReactNode;
+};
+
+const LayoutContainer = ({ children }: Props) => {
+  return (
+    <>
+      <LayoutHeader />
+      <LayoutNavigation />
+      <main className={`h-full w-full pl-nav pt-header`}>{children}</main>
+    </>
+  );
+};
+
+export default LayoutContainer;

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -1,14 +1,38 @@
-import {
-  Divider,
-  Drawer,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  Toolbar,
-} from '@mui/material';
+import { Drawer, List, ListItem, ListItemIcon, ListItemText, Toolbar } from '@mui/material';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+import GridViewIcon from '@mui/icons-material/GridView';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useCallback } from 'react';
+import { SidebarType } from 'src/types/common';
+import { memo } from 'react';
+
+const sidebar: SidebarType[] = [
+  { label: '유저', path: 'user', icon: <PersonOutlineIcon /> },
+  { label: '메인 콘텐츠', path: 'main', icon: <GridViewIcon /> },
+];
 
 const LayoutNavigation = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const current = location.pathname.replace(/[/]/, '');
+
+  const onChangeRoute = useCallback(
+    (v: string) => {
+      if (current === v) {
+        console.log('current');
+
+        return;
+      }
+      navigate(v);
+    },
+    [location]
+  );
+
+  // useEffect(() => {
+  //   console.log('location', location);
+  // }, [location]);
+
   return (
     <Drawer
       variant='permanent'
@@ -24,16 +48,19 @@ const LayoutNavigation = () => {
       <Toolbar
         sx={{
           height: 'var(--layout-header)',
+          boxSizing: 'content-box',
         }}
       >
         App icon
       </Toolbar>
-      <Divider />
       <List>
-        {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
-          <ListItem button key={text}>
-            {/* <ListItemIcon>{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}</ListItemIcon> */}
-            <ListItemText primary={text} />
+        {sidebar.map((v, i) => (
+          <ListItem button key={i} onClick={() => onChangeRoute(v.path)}>
+            <ListItemIcon>{v.icon}</ListItemIcon>
+            <ListItemText primary={v.label} />
+            <aside
+              className={`absolute top-0 left-0 h-full w-2 ${current === v.path && 'bg-gray-300'}`}
+            />
           </ListItem>
         ))}
       </List>
@@ -41,4 +68,4 @@ const LayoutNavigation = () => {
   );
 };
 
-export default LayoutNavigation;
+export default memo(LayoutNavigation);

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -1,0 +1,44 @@
+import {
+  Divider,
+  Drawer,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Toolbar,
+} from '@mui/material';
+
+const LayoutNavigation = () => {
+  return (
+    <Drawer
+      variant='permanent'
+      sx={{
+        display: { xs: 'none', sm: 'block' },
+        '& .MuiDrawer-paper': {
+          boxSizing: 'border-box',
+          width: 'var(--layout-nav)',
+        },
+      }}
+      open
+    >
+      <Toolbar
+        sx={{
+          height: 'var(--layout-header)',
+        }}
+      >
+        App icon
+      </Toolbar>
+      <Divider />
+      <List>
+        {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
+          <ListItem button key={text}>
+            {/* <ListItemIcon>{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}</ListItemIcon> */}
+            <ListItemText primary={text} />
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+};
+
+export default LayoutNavigation;

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -1,7 +1,7 @@
 export default function UserPage() {
   return (
     <div>
-      <h1 className='bg-slate-400 text-red-500'>User Page</h1>
+      <h1>User Page</h1>
       hello
     </div>
   );

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,6 +12,12 @@ export default function Routes() {
   const location = useLocation();
   const navigate = useNavigate();
 
+  useEffect(() => {
+    if (location.pathname === '/') {
+      navigate('login');
+    }
+  });
+
   const routes = useRoutes([
     { path: 'login', element: <Login /> },
     {
@@ -30,12 +36,6 @@ export default function Routes() {
     },
     { path: '*', element: <Error /> },
   ]);
-
-  useEffect(() => {
-    if (location.pathname === '/') {
-      navigate('login');
-    }
-  });
 
   return routes;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,3 +13,19 @@ h2 {
 h3 {
   @apply text-lg;
 }
+
+html, body{
+  min-width: 1400px;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+}
+#root{
+  width: 100%;
+  height: 100%;
+}
+
+:root{
+  --layout-header: 90px;
+  --layout-nav: 240px;
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react';
+
+export type SidebarType = {
+  label: string;
+  path: string;
+  icon: ReactNode;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,12 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      spacing: {
+        header: 'var(--layout-header)',
+        nav: 'var(--layout-nav)',
+      },
+    },
   },
   plugins: [],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
       "src/*": [
         "./src/*"
       ]
-    }
+    },
+    "incremental": true,
   },
   "include": [
     "./src",


### PR DESCRIPTION
### 작업내용
- nav바
  - 메뉴분리
  - router 이동
- 헤더
  - 로그아웃

### 전달사항
1. custom > alert 폴더내에 커스텀 모달(확인, 취소버튼 O) 만들어놨으니 필요한 경우 사용하세요.
2. 적응형으로 `min-width: 1400px`로 잡아놨는데, 너무 작거나 큰경우 조절해주세요.
3.  primary 색상은 tailwind의 `...-gray-200`을, 강조하는 부분은 `...-gray-300`를 사용했습니다. 추후 변경시 레이아웃도 적용 부탁드립니다!